### PR TITLE
prevent handling events from fake players

### DIFF
--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -27,6 +27,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
@@ -190,6 +191,7 @@ public class ForgeWorldEdit {
         if (!platform.isHookingEvents()) return; // We have to be told to catch these events
 
         if (event.useItem == Result.DENY || event.entity.worldObj.isRemote) return;
+        if (event.entityPlayer instanceof FakePlayer) return;
 
         WorldEdit we = WorldEdit.getInstance();
         if (event.entityPlayer instanceof EntityPlayerMP) {


### PR DESCRIPTION
```
java.lang.reflect.InvocationTargetException
        at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:76)
        at com.sk89q.worldedit.util.eventbus.EventBus.dispatch(EventBus.java:197)
        at com.sk89q.worldedit.util.eventbus.EventBus.post(EventBus.java:183)
        at com.sk89q.worldedit.WorldEdit.handleRightClick(WorldEdit.java:687)
        at com.sk89q.worldedit.forge.ForgeWorldEdit.onPlayerInteract(ForgeWorldEdit.java:222)
        at cpw.mods.fml.common.eventhandler.ASMEventHandler_1315_ForgeWorldEdit_onPlayerInteract_PlayerInteractEvent.invoke(.dynamic)
        at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
        at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
        at net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(ForgeEventFactory.java:100)
        at net.minecraft.server.management.ItemInWorldManager.func_73078_a(ItemInWorldManager.java:353)
        at thaumcraft.common.entities.ai.interact.AIUseItem.click(AIUseItem.java:158)
        at thaumcraft.common.entities.ai.interact.AIUseItem.func_75246_d(AIUseItem.java:99)
        at net.minecraft.entity.ai.EntityAITasks.func_75774_a(SourceFile:103)
        at makeo.gadomancy.common.entities.golems.cores.EntityAITasksWrapper.func_75774_a(EntityAITasksWrapper.java:83)
        at net.minecraft.entity.EntityLiving.func_70619_bc(EntityLiving.java:540)
        at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:1774)
        at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:367)
        at thaumcraft.common.entities.golems.EntityGolemBase.func_70636_d(EntityGolemBase.java:354)
        at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:1611)
        at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:206)
        at net.minecraft.world.World.func_72866_a(World.java:2070)
        at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:648)
        at net.minecraft.world.World.func_72870_g(World.java:2034)
        at net.minecraft.world.World.func_72939_s(World.java:1887)
        at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
        at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.GeneratedMethodAccessor57.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.lang.reflect.Method.invoke(Unknown Source)
        at com.sk89q.worldedit.util.eventbus.MethodEventHandler.dispatch(MethodEventHandler.java:55)
        at com.sk89q.worldedit.util.eventbus.EventHandler.handleEvent(EventHandler.java:74)
        ... 29 more
Caused by: java.lang.NullPointerException
```