### PR TITLE
New Command //material

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -48,8 +48,9 @@ dependencies {
     devOnlyNonPublishable 'com.github.GTNewHorizons:ArchitectureCraft:1.10.2:dev'
     devOnlyNonPublishable 'com.github.GTNewHorizons:ForgeMultipart:1.5.1:dev'
     devOnlyNonPublishable 'com.github.GTNewHorizons:CarpentersBlocks:3.7.0-GTNH:dev'
+    devOnlyNonPublishable 'com.github.GTNewHorizons:LittleTiles:1.6.0:dev'
 
-    runtimeOnlyNonPublishable 'com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev'
+    //runtimeOnlyNonPublishable 'com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev'
 
     testImplementation 'org.mockito:mockito-core:5.4.0'
 }

--- a/src/main/java/com/sk89q/jnbt/CompoundTag.java
+++ b/src/main/java/com/sk89q/jnbt/CompoundTag.java
@@ -341,6 +341,25 @@ public final class CompoundTag extends Tag {
     }
 
     /**
+     * Get a CompoundTag named with the given key.
+     *
+     * <p>
+     * If the key does not exist or its value is not a CompoundTag,
+     * then {@code null} will be returned.
+     * </p>
+     *
+     * @param key the key
+     * @return a CompoundTag
+     */
+    public CompoundTag getCompoundtag(String key) {
+        Tag tag = value.get(key);
+        if (tag instanceof CompoundTag compoundTag) {
+           return compoundTag;
+        }
+        return null;
+    }
+
+    /**
      * Get a long named with the given key.
      *
      * <p>

--- a/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -60,6 +60,7 @@ import com.sk89q.worldedit.function.GroundFunction;
 import com.sk89q.worldedit.function.RegionMaskingFilter;
 import com.sk89q.worldedit.function.block.BlockReplace;
 import com.sk89q.worldedit.function.block.Counter;
+import com.sk89q.worldedit.function.block.MaterialReplace;
 import com.sk89q.worldedit.function.block.Naturalizer;
 import com.sk89q.worldedit.function.generator.GardenPatchGenerator;
 import com.sk89q.worldedit.function.mask.BlockMask;
@@ -987,6 +988,26 @@ public class EditSession implements Extent {
         BlockReplace replace = new BlockReplace(this, Patterns.wrap(pattern));
         RegionMaskingFilter filter = new RegionMaskingFilter(mask, replace);
         RegionVisitor visitor = new RegionVisitor(region, filter);
+        Operations.completeLegacy(visitor);
+        return visitor.getAffected();
+    }
+
+    /**
+     * Replaces all the material in specific blocks matching a given mask, within a given region, to a block
+     * returned by a given pattern.
+     *
+     * @param region  the region to replace the blocks within
+     * @param pattern the pattern that provides the new blocks
+     * @return number of blocks affected
+     * @throws MaxChangedBlocksException thrown if too many blocks are changed
+     */
+    @SuppressWarnings("deprecation")
+    public int replaceMaterial(Region region, Pattern pattern) throws MaxChangedBlocksException {
+        checkNotNull(region);
+        checkNotNull(pattern);
+
+        MaterialReplace replace = new MaterialReplace(this, Patterns.wrap(pattern));
+        RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);
         return visitor.getAffected();
     }

--- a/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -156,6 +156,24 @@ public class RegionCommands {
     }
 
     @Command(
+        aliases = { "/material", "/ma", "/mat" },
+        usage = "[from-block] <to-block>",
+        desc = "Replace all blocks in the selection with another",
+        flags = "f",
+        min = 1,
+        max = 2)
+    @CommandPermissions("worldedit.region.replace")
+    @Logging(REGION)
+    public void material(Player player, EditSession editSession, @Selection Region region, @Optional Mask from,
+                        Pattern to) throws WorldEditException {
+        if (from == null) {
+            from = new ExistingBlockMask(editSession);
+        }
+        int affected = editSession.replaceMaterial(region, Patterns.wrap(to));
+        player.print(affected + " block(s) have been replaced.");
+    }
+
+    @Command(
         aliases = { "/overlay" },
         usage = "<block>",
         desc = "Set a block on top of blocks in the region",

--- a/src/main/java/com/sk89q/worldedit/extent/transform/MaterialTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/extent/transform/MaterialTransformHook.java
@@ -1,0 +1,9 @@
+package com.sk89q.worldedit.extent.transform;
+
+import com.sk89q.worldedit.blocks.BaseBlock;
+
+public interface MaterialTransformHook {
+
+    BaseBlock transformMaterial(BaseBlock block, BaseBlock newMaterial);
+
+}

--- a/src/main/java/com/sk89q/worldedit/extent/transform/MaterialTransformHooks.java
+++ b/src/main/java/com/sk89q/worldedit/extent/transform/MaterialTransformHooks.java
@@ -1,0 +1,23 @@
+package com.sk89q.worldedit.extent.transform;
+
+import com.sk89q.worldedit.blocks.BaseBlock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MaterialTransformHooks implements MaterialTransformHook {
+
+    private final List<MaterialTransformHook> hooks = new ArrayList<>();
+
+    public void addHook(MaterialTransformHook hook) {
+        hooks.add(hook);
+    }
+
+    @Override
+    public BaseBlock transformMaterial(BaseBlock block, BaseBlock newMaterial) {
+        for (MaterialTransformHook hook : hooks) {
+            block = hook.transformMaterial(block, newMaterial);
+        }
+        return block;
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java
@@ -170,7 +170,7 @@ public class ForgeWorld extends AbstractWorld {
             previousId = Block.getIdFromBlock(chunk.getBlock(x & 15, y, z & 15));
         }
 
-        boolean successful = chunk.func_150807_a(x & 15, y, z & 15, Block.getBlockById(block.getId()), block.getData());
+        boolean successful = true; // = chunk.func_150807_a(x & 15, y, z & 15, Block.getBlockById(block.getId()), block.getData());
 
         // Create the TileEntity
         if (successful) {

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldData.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldData.java
@@ -23,7 +23,7 @@ import com.sk89q.worldedit.world.registry.LegacyWorldData;
 /**
  * World data for the Forge platform.
  */
-class ForgeWorldData extends LegacyWorldData {
+public class ForgeWorldData extends LegacyWorldData {
 
     private static final ForgeWorldData INSTANCE = new ForgeWorldData();
     private final ItemRegistry itemRegistry = new ForgeItemRegistry();

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -88,7 +88,8 @@ public class ForgeWorldEdit {
     private ForgePlatform platform;
     private ForgeConfiguration config;
     private File workingDir;
-    private ForgeMultipartCompat compat = new NoForgeMultipartCompat();
+    private ForgeMultipartCompat fmpCompat = new NoForgeMultipartCompat();
+    private LittleTilesCompat ltCompat = new NoLittleTilesCompat();
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -101,9 +102,9 @@ public class ForgeWorldEdit {
         config.load();
 
         if (Loader.isModLoaded("ForgeMultipart")) {
-            compat = new ForgeMultipartExistsCompat();
+            fmpCompat = new ForgeMultipartExistsCompat();
             ForgeWorldData.getInstance()
-                .addBlockTransformHook((ForgeMultipartExistsCompat) compat);
+                .addBlockTransformHook((ForgeMultipartExistsCompat) fmpCompat);
             ForgeWorldData.getInstance()
                 .addMaterialTransformHook(new ForgeMultipartBlockMaterialTransformHook());
         }
@@ -117,6 +118,12 @@ public class ForgeWorldEdit {
             ForgeWorldData.getInstance()
                 .addBlockTransformHook(new CarpentersBlocksBlockTransformHook());
         }
+        if (Loader.isModLoaded("littletiles")) {
+            ltCompat = new LittleTilesExistsCompat();
+            ForgeWorldData.getInstance()
+                .addMaterialTransformHook(new LittleTilesBlockMaterialTransformHook());
+        }
+
 
         FMLCommonHandler.instance()
             .bus()
@@ -319,7 +326,11 @@ public class ForgeWorldEdit {
     }
 
     public ForgeMultipartCompat getFMPCompat() {
-        return compat;
+        return fmpCompat;
+    }
+
+    public LittleTilesCompat getLtCompat() {
+        return ltCompat;
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -104,6 +104,8 @@ public class ForgeWorldEdit {
             compat = new ForgeMultipartExistsCompat();
             ForgeWorldData.getInstance()
                 .addBlockTransformHook((ForgeMultipartExistsCompat) compat);
+            ForgeWorldData.getInstance()
+                .addMaterialTransformHook(new ForgeMultipartBlockMaterialTransformHook());
         }
         if (Loader.isModLoaded("ArchitectureCraft")) {
             ForgeWorldData.getInstance()

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -22,6 +22,7 @@ import static net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import java.io.File;
 import java.util.Map;
 
+import com.sk89q.worldedit.forge.compat.*;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -42,11 +43,6 @@ import com.sk89q.worldedit.blocks.BaseBlock;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.event.platform.PlatformReadyEvent;
 import com.sk89q.worldedit.extension.platform.Platform;
-import com.sk89q.worldedit.forge.compat.ArchitectureCraftBlockTransformHook;
-import com.sk89q.worldedit.forge.compat.CarpentersBlocksBlockTransformHook;
-import com.sk89q.worldedit.forge.compat.ForgeMultipartCompat;
-import com.sk89q.worldedit.forge.compat.ForgeMultipartExistsCompat;
-import com.sk89q.worldedit.forge.compat.NoForgeMultipartCompat;
 import com.sk89q.worldedit.internal.LocalWorldAdapter;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -112,6 +108,8 @@ public class ForgeWorldEdit {
         if (Loader.isModLoaded("ArchitectureCraft")) {
             ForgeWorldData.getInstance()
                 .addBlockTransformHook(new ArchitectureCraftBlockTransformHook());
+            ForgeWorldData.getInstance()
+                .addMaterialTransformHook(new ArchitectureCraftBlockMaterialTransformHook());
         }
         if (Loader.isModLoaded("CarpentersBlocks")) {
             ForgeWorldData.getInstance()

--- a/src/main/java/com/sk89q/worldedit/forge/TileEntityUtils.java
+++ b/src/main/java/com/sk89q/worldedit/forge/TileEntityUtils.java
@@ -75,5 +75,7 @@ final class TileEntityUtils {
         world.setTileEntity(position.getBlockX(), position.getBlockY(), position.getBlockZ(), tileEntity);
         ForgeWorldEdit.inst.getFMPCompat()
             .sendDescPacket(world, tileEntity);
+        ForgeWorldEdit.inst.getLtCompat()
+            .sendDescPacket(world, tileEntity);
     }
 }

--- a/src/main/java/com/sk89q/worldedit/forge/compat/ArchitectureCraftBlockMaterialTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/ArchitectureCraftBlockMaterialTransformHook.java
@@ -1,0 +1,26 @@
+package com.sk89q.worldedit.forge.compat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
+import net.minecraft.block.Block;
+
+public class ArchitectureCraftBlockMaterialTransformHook implements MaterialTransformHook {
+
+    @Override
+    public BaseBlock transformMaterial(BaseBlock block, BaseBlock newMaterial) {
+        CompoundTag nbt = block.getNbtData();
+        if (nbt == null) {
+            return block;
+        }
+        if (!"gcewing.shape".equals(nbt.getString("id"))) {
+            return block;
+        }
+
+        CompoundTagBuilder newNbt = nbt.createBuilder();
+        newNbt.putString("BaseName", Block.blockRegistry.getNameForObject(Block.getBlockById(newMaterial.getId())));
+        newNbt.putInt("BaseData", newMaterial.getData());
+        return new BaseBlock(block.getId(), block.getData(), newNbt.build());
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/ForgeMultipartBlockMaterialTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/ForgeMultipartBlockMaterialTransformHook.java
@@ -1,0 +1,39 @@
+package com.sk89q.worldedit.forge.compat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
+import com.sk89q.jnbt.ListTag;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
+import net.minecraft.block.Block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ForgeMultipartBlockMaterialTransformHook implements MaterialTransformHook {
+
+    @Override
+    public BaseBlock transformMaterial(BaseBlock block, BaseBlock newMaterial) {
+        CompoundTag nbt = block.getNbtData();
+        if (nbt == null) {
+            return block;
+        }
+        if (!"savedMultipart".equals(nbt.getString("id"))) {
+            return block;
+        }
+
+        CompoundTagBuilder builder = nbt.createBuilder();
+
+        List<CompoundTag> parts = new ArrayList<>(nbt.getList("parts", CompoundTag.class));
+        for (int i = 0; i < parts.size(); i++) {
+            CompoundTag part = parts.get(i);
+            CompoundTagBuilder partBuilder = part.createBuilder();
+            partBuilder.putString("material", Block.blockRegistry.getNameForObject(Block.getBlockById(newMaterial.getId())));
+            parts.set(i, partBuilder.build());
+        }
+        builder.put("parts", new ListTag(CompoundTag.class, parts));
+
+        return new BaseBlock(block.getId(), block.getData(), builder.build());
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesBlockMaterialTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesBlockMaterialTransformHook.java
@@ -1,0 +1,44 @@
+package com.sk89q.worldedit.forge.compat;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.CompoundTagBuilder;
+import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
+import net.minecraft.block.Block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LittleTilesBlockMaterialTransformHook implements MaterialTransformHook {
+
+    @Override
+    public BaseBlock transformMaterial(BaseBlock block, BaseBlock newMaterial) {
+        CompoundTag nbt = block.getNbtData();
+        if (nbt == null) {
+            return block;
+        }
+        if (!"LittleTilesTileEntity".equals(nbt.getString("id"))) {
+            return block;
+        }
+
+        int tileCount = nbt.getInt("tilesCount");
+        if (tileCount <= 0) {
+            return block;
+        }
+
+        CompoundTagBuilder fullTileBuilder = nbt.createBuilder();
+        for (int i = 0; i < tileCount; i++) {
+            CompoundTag subTileNbt = nbt.getCompoundtag("t" + i);
+            if (subTileNbt == null)
+                continue;
+
+            CompoundTagBuilder subTileBuilder = subTileNbt.createBuilder();
+            subTileBuilder.putString("block", Block.blockRegistry.getNameForObject(Block.getBlockById(newMaterial.getId())));
+            subTileBuilder.putInt("meta", newMaterial.getData());
+            fullTileBuilder.put("t" + i, subTileBuilder.build());
+        }
+
+        return new BaseBlock(block.getId(), block.getData(), fullTileBuilder.build());
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesCompat.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesCompat.java
@@ -1,0 +1,10 @@
+package com.sk89q.worldedit.forge.compat;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public interface LittleTilesCompat {
+
+    void sendDescPacket(World world, TileEntity entity);
+
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesExistsCompat.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesExistsCompat.java
@@ -9,6 +9,7 @@ public class LittleTilesExistsCompat implements LittleTilesCompat{
     @Override
     public void sendDescPacket(World world, TileEntity entity) {
         if (entity instanceof TileEntityLittleTiles littleTile) {
+            littleTile.needFullUpdate = true;
             world.markBlockForUpdate(littleTile.xCoord, littleTile.yCoord, littleTile.zCoord);
             littleTile.markDirty();
         }

--- a/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesExistsCompat.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/LittleTilesExistsCompat.java
@@ -1,0 +1,17 @@
+package com.sk89q.worldedit.forge.compat;
+
+import com.creativemd.littletiles.common.tileentity.TileEntityLittleTiles;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public class LittleTilesExistsCompat implements LittleTilesCompat{
+
+    @Override
+    public void sendDescPacket(World world, TileEntity entity) {
+        if (entity instanceof TileEntityLittleTiles littleTile) {
+            world.markBlockForUpdate(littleTile.xCoord, littleTile.yCoord, littleTile.zCoord);
+            littleTile.markDirty();
+        }
+
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/NoLittleTilesCompat.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/NoLittleTilesCompat.java
@@ -1,0 +1,12 @@
+package com.sk89q.worldedit.forge.compat;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public class NoLittleTilesCompat implements LittleTilesCompat{
+
+    @Override
+    public void sendDescPacket(World world, TileEntity entity) {
+
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/function/block/MaterialReplace.java
+++ b/src/main/java/com/sk89q/worldedit/function/block/MaterialReplace.java
@@ -1,0 +1,43 @@
+package com.sk89q.worldedit.function.block;
+
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
+import com.sk89q.worldedit.forge.ForgeWorldData;
+import com.sk89q.worldedit.function.RegionFunction;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.world.registry.LegacyWorldData;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Replaces the blocks material with a given pattern.
+ */
+public class MaterialReplace implements RegionFunction {
+
+    private final Extent extent;
+    private Pattern pattern;
+
+    /**
+     * Create a new instance.
+     *
+     * @param extent  an extent
+     * @param pattern a pattern
+     */
+    public MaterialReplace(Extent extent, Pattern pattern) {
+        checkNotNull(extent);
+        checkNotNull(pattern);
+        this.extent = extent;
+        this.pattern = pattern;
+    }
+
+    @Override
+    public boolean apply(Vector position) throws WorldEditException {
+        MaterialTransformHook hook = ForgeWorldData.getInstance().getMaterialTransformHook();
+        BaseBlock transformedBaseBlock = hook.transformMaterial(extent.getBlock(position),pattern.apply(position));
+        extent.setBlock(position, transformedBaseBlock);
+        return true;
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/world/registry/LegacyWorldData.java
+++ b/src/main/java/com/sk89q/worldedit/world/registry/LegacyWorldData.java
@@ -18,6 +18,8 @@ package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.extent.transform.BlockTransformHook;
 import com.sk89q.worldedit.extent.transform.BlockTransformHooks;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHooks;
 
 /**
  * An implementation of {@link WorldData} that uses legacy numeric IDs and
@@ -31,6 +33,7 @@ public class LegacyWorldData implements WorldData {
     private final NullEntityRegistry entityRegistry = new NullEntityRegistry();
     private final NullBiomeRegistry biomeRegistry = new NullBiomeRegistry();
     protected final BlockTransformHooks blockTransformHooks = new BlockTransformHooks();
+    private final MaterialTransformHooks materialReplaceHooks = new MaterialTransformHooks();
 
     /**
      * Create a new instance.
@@ -62,8 +65,17 @@ public class LegacyWorldData implements WorldData {
         return blockTransformHooks;
     }
 
+    @Override
+    public MaterialTransformHook getMaterialTransformHook() {
+        return materialReplaceHooks;
+    }
+
     public void addBlockTransformHook(BlockTransformHook hook) {
         blockTransformHooks.addHook(hook);
+    }
+
+    public void addMaterialTransformHook(MaterialTransformHook hook) {
+        materialReplaceHooks.addHook(hook);
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/world/registry/WorldData.java
+++ b/src/main/java/com/sk89q/worldedit/world/registry/WorldData.java
@@ -17,6 +17,7 @@
 package com.sk89q.worldedit.world.registry;
 
 import com.sk89q.worldedit.extent.transform.BlockTransformHook;
+import com.sk89q.worldedit.extent.transform.MaterialTransformHook;
 
 /**
  * Describes the necessary data for blocks, entities, and other objects
@@ -53,4 +54,6 @@ public interface WorldData {
     BiomeRegistry getBiomeRegistry();
 
     BlockTransformHook getBlockTransformHook();
+
+    MaterialTransformHook getMaterialTransformHook();
 }


### PR DESCRIPTION
This is a draft for a new command `//material`, `//mat` or `//ma` for short.
This command is intended to apply a WorldEdit pattern like `dirt` or `60%wool:3,30%cobblestone,10%stone` to blocks that can have different materials applied to them. For example ForgeMultiPart or Archicturecraft Shapes. It is intended that the orientation or other data about these blocks is preserved and only the applied material is changed. 
Normal blocks should be modified with existing means like `//replace`.


This draft aims to add an extendible way of registering special handling for these kinds of blocks. 
With 2 mods already made compatible:
- ForgeMultiPart
- Architecturecraft
- LittleTiles

Two gifs of the command being used.

![worldedit_material](https://github.com/user-attachments/assets/3844937f-c697-4227-9a9c-0941060d84ee)

![worldedit_material_fmp](https://github.com/user-attachments/assets/7adf7290-e23c-43d9-b835-10074692b36c)


# Things I need help with for this draft:
- I made `ForgeWorldData`  public to access it's instance in `MaterialReplace` which definitely isn't ideal but I wasn't able to find a different solution besides passing world context throughout the command's execution. If someone has experience with WorldEdit please chime in
---
- `MaterialReplace` will always return `true` at the moment since the `setBlock` callstack only returns `true` if the newBlock and oldBlock have differences in id or metadata which isn't the case as only NBT is getting modified. The blocks still get replaced with my current implementation but I lack knowledge regarding WorldEdit if this could cause issues. https://github.com/GTNewHorizons/worldedit-gtnh/blob/d251628339ac9261888e35b887371ffa49641d54/src/main/java/com/sk89q/worldedit/extent/reorder/MultiStageReorder.java#L92-L115
---
## THIS BREAKS EVERYTHING BESIDES THE NEW COMMAND !
- The biggest issue is `ForgeWorld#setBlock` https://github.com/GTNewHorizons/worldedit-gtnh/blob/d251628339ac9261888e35b887371ffa49641d54/src/main/java/com/sk89q/worldedit/forge/ForgeWorld.java#L173. This method actually modifies the World and places down the blocks but like in the issue mentioned above the method only compared is and metadata and therefor returns false, causing the changes not to be actually saved to the world.
---
- Little Tiles compatability is somewhat implemented but changes aren't synched to the client yet. I'm not well versed in synching data to the client in 1.7.10 and help would be much appreciated.
---
- Lastly I am wondering if how I structured everything even makes sense. I placed classes where I thought they might fit to get a quick prototype going. 
---
I welcome any suggestions, fixes or other contributions to turn this draft into a fully functional feature that can be merged.
You can also ping me in the GTNH Discord under the same username.