### PR TITLE
Feature/24/endless id schematic support

### DIFF
--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -329,7 +329,7 @@ public class SchematicReader implements ClipboardReader {
                                         itemMap.put(
                                             idPtr[0],
                                             new IntTag(
-                                                newId + (id_data & 0xff000000) != 0 ? (id_data & 0xFFFF0000) : 0));
+                                                newId + ((id_data & 0xff000000) != 0 ? (id_data & 0xFFFF0000) : 0)));
                                     } else {
                                         itemMap.put(idPtr[0], new ShortTag((short) newId));
                                     }

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -135,25 +135,45 @@ public class SchematicReader implements ClipboardReader {
         // Blocks
         // ====================================================================
 
-        Map<Short, Short> blockConversionMap = new HashMap<>();
+        Map<Integer, Integer> blockConversionMap = new HashMap<>();
         if (schematic.containsKey("BlockMapping")) {
             Map<String, Tag> mapping = requireTag(schematic, "BlockMapping", CompoundTag.class).getValue();
 
             for (String key : mapping.keySet()) {
                 short sourceId = requireTag(mapping, key, ShortTag.class).getValue();
                 Block block = Block.getBlockFromName(key);
-                blockConversionMap.put(sourceId, (short) Block.getIdFromBlock(block));
+                blockConversionMap.put(Short.toUnsignedInt(sourceId), Block.getIdFromBlock(block));
             }
         }
 
-        Map<Short, Short> itemConversionMap = new HashMap<>();
+        if (schematic.containsKey("BlockMappingE")) {
+            Map<String, Tag> mapping = requireTag(schematic, "BlockMappingE", CompoundTag.class).getValue();
+
+            for (String key : mapping.keySet()) {
+                int sourceId = requireTag(mapping, key, IntTag.class).getValue();
+                Block block = Block.getBlockFromName(key);
+                blockConversionMap.put(sourceId, Block.getIdFromBlock(block));
+            }
+        }
+
+        Map<Integer, Integer> itemConversionMap = new HashMap<>();
         if (schematic.containsKey("ItemMapping")) {
             Map<String, Tag> mapping = requireTag(schematic, "ItemMapping", CompoundTag.class).getValue();
 
             for (String key : mapping.keySet()) {
                 short sourceId = requireTag(mapping, key, ShortTag.class).getValue();
                 Item item = (Item) Item.itemRegistry.getObject(key);
-                itemConversionMap.put(sourceId, (short) Item.getIdFromItem(item));
+                itemConversionMap.put(Short.toUnsignedInt(sourceId), Item.getIdFromItem(item));
+            }
+        }
+
+        if (schematic.containsKey("ItemMappingE")) {
+            Map<String, Tag> mapping = requireTag(schematic, "ItemMapping", CompoundTag.class).getValue();
+
+            for (String key : mapping.keySet()) {
+                int sourceId = requireTag(mapping, key, IntTag.class).getValue();
+                Item item = (Item) Item.itemRegistry.getObject(key);
+                itemConversionMap.put(sourceId, Item.getIdFromItem(item));
             }
         }
 
@@ -167,7 +187,7 @@ public class SchematicReader implements ClipboardReader {
 
         byte[] addId = new byte[0];
         byte[] addId2 = new byte[0];
-        short[] blocks = new short[blockId.length]; // Have to later combine IDs
+        int[] blocks = new int[blockId.length]; // Have to later combine IDs
 
         // We support 4096 block IDs using the same method as vanilla Minecraft, where
         // the highest 4 bits are stored in a separate byte array.
@@ -280,21 +300,21 @@ public class SchematicReader implements ClipboardReader {
                             public CompoundTag apply(CompoundTag nbtData) {
                                 String[] idPtr = new String[1];
                                 if (isItem.test(nbtData, idPtr)) {
-                                    short id;
+                                    int id;
                                     Integer id_data = null;
                                     if (nbtData.getValue()
                                         .get(idPtr[0]) instanceof IntTag) {
                                         id_data = nbtData.getInt(idPtr[0]);
-                                        id = id_data.shortValue();
+                                        id = id_data;
                                     } else {
-                                        id = nbtData.getShort(idPtr[0]);
+                                        id = Short.toUnsignedInt(nbtData.getShort(idPtr[0]));
                                     }
                                     HashMap<String, Tag> itemMap = new HashMap<>(nbtData.getValue());
-                                    short newId = itemConversionMap.getOrDefault(id, id);
+                                    int newId = itemConversionMap.getOrDefault(id, id);
                                     if (id_data != null) {
-                                        itemMap.put(idPtr[0], new IntTag(newId + (id_data & 0xFFFF0000)));
+                                        itemMap.put(idPtr[0], new IntTag(newId));
                                     } else {
-                                        itemMap.put(idPtr[0], new ShortTag(newId));
+                                        itemMap.put(idPtr[0], new ShortTag((short) newId));
                                     }
 
                                     if (nbtData.containsKey("tag") && itemMap.get("tag") instanceof CompoundTag nbt) {
@@ -316,41 +336,31 @@ public class SchematicReader implements ClipboardReader {
                                         if (nbtData.containsKey(key = "bottomMaterial") && nbtData.getValue()
                                             .get(key) instanceof IntTag itag) {
                                             int _id = itag.getValue();
-                                            nbtMap.put(
-                                                key,
-                                                new IntTag(itemConversionMap.getOrDefault((short) _id, (short) _id)));
+                                            nbtMap.put(key, new IntTag(itemConversionMap.getOrDefault(_id, _id)));
                                         }
 
                                         if (nbtData.containsKey(key = "topMaterial") && nbtData.getValue()
                                             .get(key) instanceof IntTag itag) {
                                             int _id = itag.getValue();
-                                            nbtMap.put(
-                                                key,
-                                                new IntTag(itemConversionMap.getOrDefault((short) _id, (short) _id)));
+                                            nbtMap.put(key, new IntTag(itemConversionMap.getOrDefault(_id, _id)));
                                         }
 
                                         if (nbtData.containsKey(key = "frame") && nbtData.getValue()
                                             .get(key) instanceof IntTag itag) {
                                             int _id = itag.getValue();
-                                            nbtMap.put(
-                                                key,
-                                                new IntTag(itemConversionMap.getOrDefault((short) _id, (short) _id)));
+                                            nbtMap.put(key, new IntTag(itemConversionMap.getOrDefault(_id, _id)));
                                         }
 
                                         if (nbtData.containsKey(key = "block") && nbtData.getValue()
                                             .get(key) instanceof IntTag itag) {
                                             int _id = itag.getValue();
-                                            nbtMap.put(
-                                                key,
-                                                new IntTag(blockConversionMap.getOrDefault((short) _id, (short) _id)));
+                                            nbtMap.put(key, new IntTag(blockConversionMap.getOrDefault(_id, _id)));
                                         }
 
                                         if (nbtData.containsKey(key = "item") && nbtData.getValue()
                                             .get(key) instanceof IntTag itag) {
                                             int _id = itag.getValue();
-                                            nbtMap.put(
-                                                key,
-                                                new IntTag(itemConversionMap.getOrDefault((short) _id, (short) _id)));
+                                            nbtMap.put(key, new IntTag(itemConversionMap.getOrDefault(_id, _id)));
                                         }
                                     }
 

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -187,6 +187,7 @@ public class SchematicReader implements ClipboardReader {
 
         byte[] addId = new byte[0];
         byte[] addId2 = new byte[0];
+        byte[] addId3 = new byte[0];
         int[] blocks = new int[blockId.length]; // Have to later combine IDs
 
         // We support 4096 block IDs using the same method as vanilla Minecraft, where
@@ -197,6 +198,10 @@ public class SchematicReader implements ClipboardReader {
 
         if (schematic.containsKey("AddBlocks2")) {
             addId2 = requireTag(schematic, "AddBlocks2", ByteArrayTag.class).getValue();
+        }
+
+        if (schematic.containsKey("AddBlocks3")) {
+            addId3 = requireTag(schematic, "AddBlocks3", ByteArrayTag.class).getValue();
         }
         // Combine the AddBlocks data with the first 8-bit block ID
         for (int index = 0; index < blockId.length; index++) {
@@ -218,6 +223,12 @@ public class SchematicReader implements ClipboardReader {
                 } else {
                     blocks[index] = (short) (((addId2[index >> 1] & 0xF0) << 8) + (blocks[index] & 0xFFF));
                 }
+            }
+        }
+
+        if (addId3.length == blockId.length) {
+            for (int index = 0; index < blockId.length; index++) {
+                blocks[index] = (addId3[index] << 16) + (blocks[index] & 0xFFFF);
             }
         }
 

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -317,13 +317,19 @@ public class SchematicReader implements ClipboardReader {
                                         .get(idPtr[0]) instanceof IntTag) {
                                         id_data = nbtData.getInt(idPtr[0]);
                                         id = id_data;
+                                        if ((id_data & 0xff000000) != 0) {
+                                            id = id & 0x0000ffff;
+                                        }
                                     } else {
                                         id = Short.toUnsignedInt(nbtData.getShort(idPtr[0]));
                                     }
                                     HashMap<String, Tag> itemMap = new HashMap<>(nbtData.getValue());
                                     int newId = itemConversionMap.getOrDefault(id, id);
                                     if (id_data != null) {
-                                        itemMap.put(idPtr[0], new IntTag(newId));
+                                        itemMap.put(
+                                            idPtr[0],
+                                            new IntTag(
+                                                newId + (id_data & 0xff000000) != 0 ? (id_data & 0xFFFF0000) : 0));
                                     } else {
                                         itemMap.put(idPtr[0], new ShortTag((short) newId));
                                     }

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -168,7 +168,7 @@ public class SchematicReader implements ClipboardReader {
         }
 
         if (schematic.containsKey("ItemMappingE")) {
-            Map<String, Tag> mapping = requireTag(schematic, "ItemMapping", CompoundTag.class).getValue();
+            Map<String, Tag> mapping = requireTag(schematic, "ItemMappingE", CompoundTag.class).getValue();
 
             for (String key : mapping.keySet()) {
                 int sourceId = requireTag(mapping, key, IntTag.class).getValue();

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -114,6 +114,7 @@ public class SchematicWriter implements ClipboardWriter {
         byte[] blocks = new byte[width * height * length];
         byte[] addBlocks = null;
         byte[] addBlocks2 = null;
+        byte[] addBlocks3 = null;
         byte[] blockData = new byte[width * height * length];
         byte[] addData = null;
         List<Tag> tileEntities = new ArrayList<Tag>();
@@ -126,7 +127,7 @@ public class SchematicWriter implements ClipboardWriter {
 
             int index = y * width * length + z * width + x;
             BaseBlock block = clipboard.getBlock(point);
-            boolean endlessId = block.getId() > 65535;
+            boolean endlessId = false;
             // Save 4096 IDs in an AddBlocks section
             if (block.getType() > 255) {
                 if (addBlocks == null) { // Lazily create section
@@ -146,6 +147,15 @@ public class SchematicWriter implements ClipboardWriter {
                 addBlocks2[index
                     >> 1] = (byte) (((index & 1) == 0) ? addBlocks2[index >> 1] & 0xF0 | (block.getType() >> 12) & 0xF
                         : addBlocks2[index >> 1] & 0xF | ((block.getType() >> 12) & 0xF) << 4);
+            }
+
+            if (block.getType() > 65535) {
+                endlessId = true;
+                if (addBlocks3 == null) {
+                    addBlocks3 = new byte[blocks.length];
+                }
+
+                addBlocks3[index] = (byte) (block.getType() >> 16);
             }
 
             (endlessId ? blockMappingEndless : blockMapping).put(
@@ -290,6 +300,10 @@ public class SchematicWriter implements ClipboardWriter {
 
         if (addBlocks2 != null) {
             schematic.put("AddBlocks2", new ByteArrayTag(addBlocks2));
+        }
+
+        if (addBlocks3 != null) {
+            schematic.put("AddBlocks3", new ByteArrayTag(addBlocks2));
         }
 
         if (addData != null) {

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -103,7 +103,9 @@ public class SchematicWriter implements ClipboardWriter {
         schematic.put("WEOffsetY", new IntTag(offset.getBlockY()));
         schematic.put("WEOffsetZ", new IntTag(offset.getBlockZ()));
         HashMap<String, Tag> blockMapping = new HashMap<>();
+        HashMap<String, Tag> blockMappingEndless = new HashMap<>();
         HashMap<String, Tag> itemMapping = new HashMap<>();
+        HashMap<String, Tag> itemMappingEndless = new HashMap<>();
 
         // ====================================================================
         // Block handling
@@ -124,7 +126,7 @@ public class SchematicWriter implements ClipboardWriter {
 
             int index = y * width * length + z * width + x;
             BaseBlock block = clipboard.getBlock(point);
-
+            boolean endlessId = block.getId() > 65535;
             // Save 4096 IDs in an AddBlocks section
             if (block.getType() > 255) {
                 if (addBlocks == null) { // Lazily create section
@@ -145,9 +147,10 @@ public class SchematicWriter implements ClipboardWriter {
                     >> 1] = (byte) (((index & 1) == 0) ? addBlocks2[index >> 1] & 0xF0 | (block.getType() >> 12) & 0xF
                         : addBlocks2[index >> 1] & 0xF | ((block.getType() >> 12) & 0xF) << 4);
             }
-            blockMapping.put(
+
+            (endlessId ? blockMappingEndless : blockMapping).put(
                 Block.blockRegistry.getNameForObject(Block.getBlockById(block.getId())),
-                new ShortTag((short) block.getId()));
+                endlessId ? new IntTag(block.getId()) : new ShortTag((short) block.getId()));
 
             blocks[index] = (byte) block.getType();
             blockData[index] = (byte) block.getData();
@@ -193,19 +196,17 @@ public class SchematicWriter implements ClipboardWriter {
                     public void accept(CompoundTag nbtData) {
                         String[] idPtr = new String[1];
                         if (isItem.test(nbtData, idPtr)) {
-                            short id;
+                            int id;
                             if (nbtData.getValue()
                                 .get(idPtr[0]) instanceof IntTag) {
-                                int id_data = nbtData.getInt(idPtr[0]);
-                                id = (short) id_data;
+                                id = nbtData.getInt(idPtr[0]);
 
                             } else {
-                                id = nbtData.getShort(idPtr[0]);
+                                id = Short.toUnsignedInt(nbtData.getShort(idPtr[0]));
                             }
-
-                            itemMapping.put(
-                                Item.itemRegistry.getNameForObject(Item.getItemById(Short.toUnsignedInt(id))),
-                                new ShortTag(id));
+                            (id > 65535 ? itemMappingEndless : itemMapping).put(
+                                Item.itemRegistry.getNameForObject(Item.getItemById(id)),
+                                id > 65535 ? new IntTag(id) : new ShortTag((short) id));
 
                             if (nbtData.containsKey("tag") && nbtData.getValue()
                                 .get("tag") instanceof CompoundTag nbt) {
@@ -222,41 +223,41 @@ public class SchematicWriter implements ClipboardWriter {
                                 if (nbtData.containsKey("bottomMaterial") && nbtData.getValue()
                                     .get("bottomMaterial") instanceof IntTag itag) {
                                     int _id = itag.getValue();
-                                    itemMapping.put(
+                                    (_id > 65535 ? itemMappingEndless : itemMapping).put(
                                         Item.itemRegistry.getNameForObject(Item.getItemById(_id)),
-                                        new ShortTag((short) _id));
+                                        _id > 65535 ? new IntTag(_id) : new ShortTag((short) _id));
                                 }
 
                                 if (nbtData.containsKey("topMaterial") && nbtData.getValue()
                                     .get("topMaterial") instanceof IntTag itag) {
                                     int _id = itag.getValue();
-                                    itemMapping.put(
+                                    (_id > 65535 ? itemMappingEndless : itemMapping).put(
                                         Item.itemRegistry.getNameForObject(Item.getItemById(_id)),
-                                        new ShortTag((short) _id));
+                                        _id > 65535 ? new IntTag(_id) : new ShortTag((short) _id));
                                 }
 
                                 if (nbtData.containsKey("frame") && nbtData.getValue()
                                     .get("frame") instanceof IntTag itag) {
                                     int _id = itag.getValue();
-                                    itemMapping.put(
+                                    (_id > 65535 ? itemMappingEndless : itemMapping).put(
                                         Item.itemRegistry.getNameForObject(Item.getItemById(_id)),
-                                        new ShortTag((short) _id));
+                                        _id > 65535 ? new IntTag(_id) : new ShortTag((short) _id));
                                 }
 
                                 if (nbtData.containsKey("block") && nbtData.getValue()
                                     .get("block") instanceof IntTag itag) {
                                     int _id = itag.getValue();
-                                    blockMapping.put(
+                                    (_id > 65535 ? blockMappingEndless : blockMapping).put(
                                         Item.itemRegistry.getNameForObject(Item.getItemById(_id)),
-                                        new ShortTag((short) _id));
+                                        _id > 65535 ? new IntTag(_id) : new ShortTag((short) _id));
                                 }
 
                                 if (nbtData.containsKey("item") && nbtData.getValue()
                                     .get("item") instanceof IntTag itag) {
                                     int _id = itag.getValue();
-                                    itemMapping.put(
+                                    (_id > 65535 ? itemMappingEndless : itemMapping).put(
                                         Item.itemRegistry.getNameForObject(Item.getItemById(_id)),
-                                        new ShortTag((short) _id));
+                                        _id > 65535 ? new IntTag(_id) : new ShortTag((short) _id));
                                 }
                             }
 
@@ -330,7 +331,9 @@ public class SchematicWriter implements ClipboardWriter {
         schematic.put("Entities", new ListTag(CompoundTag.class, entities));
 
         schematic.put("BlockMapping", new CompoundTag(blockMapping));
+        schematic.put("BlockMappingE", new CompoundTag(blockMappingEndless));
         schematic.put("ItemMapping", new CompoundTag(itemMapping));
+        schematic.put("ItemMappingE", new CompoundTag(itemMappingEndless));
         // ====================================================================
         // Output
         // ====================================================================

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -211,6 +211,10 @@ public class SchematicWriter implements ClipboardWriter {
                                 .get(idPtr[0]) instanceof IntTag) {
                                 id = nbtData.getInt(idPtr[0]);
 
+                                // GT edge case id+data, to differentiate from endless id 3 byte ids
+                                if ((id & 0xff000000) != 0) {
+                                    id = id & 0x0000ffff;
+                                }
                             } else {
                                 id = Short.toUnsignedInt(nbtData.getShort(idPtr[0]));
                             }


### PR DESCRIPTION
So far, the new logic seems to be working, I can load existing schematics (from earlier versions) and create new ones with everything loading as expected.  However, I have yet to test the endless id function simply because I haven't been able to find a block that is big enough to not fit into the short constraint.

Before this is merged, I would appreciate some assistance, specifically in finding a block that has an id greater than 65535 and testing said loading in both chest and in the world.  I think we can potentially hold off on merging this until we find a block that matches said condition since I think the previous build should still work with endless ids as long as there is no id greater than 65535 in the selection and I would rather wait until we have found all our edge cases instead of having an edge case discovered later when the pack expands to have such an id.

closes #24